### PR TITLE
feat: allow schedule expression and duration for rotation_rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,5 +74,7 @@ resource "aws_secretsmanager_secret_rotation" "default" {
 
   rotation_rules {
     automatically_after_days = var.rotation["automatically_after_days"]
+    duration                 = var.rotation["duration"]
+    schedule_expression      = var.rotation["schedule_expression"]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -99,11 +99,12 @@ variable "rotation" {
   type = object({
     enabled                  = optional(bool, false)
     lambda_arn               = string
-    automatically_after_days = number
+    automatically_after_days = optional(number, null)
+    duration                 = optional(string, null)
+    schedule_expression      = optional(string, null)
   })
   default = {
-    lambda_arn               = ""
-    automatically_after_days = 0
+    lambda_arn = ""
   }
   description = <<-DOC
     enabled:
@@ -113,5 +114,9 @@ variable "rotation" {
         Specifies the ARN of the Lambda function that can rotate the secret.
     automatically_after_days:
         Specifies the number of days between automatic scheduled rotations of the secret.
+    duration:
+        The length of the rotation window in hours. For example, `3h` for a three hour window.
+    schedule_expression:
+        A `cron()` or `rate()` expression that defines the schedule for rotating your secret. Either `automatically_after_days` or `schedule_expression` must be specified.
   DOC
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.16"
     }
   }
 }


### PR DESCRIPTION
# Why
This module didn't allow `duration` and `schedule_expression` for rotation_rules. 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_rotation.html

# What 
Add arguments and docs accordingly. 